### PR TITLE
preload the config module

### DIFF
--- a/lib/humidifier/loader.rb
+++ b/lib/humidifier/loader.rb
@@ -1,39 +1,50 @@
 module Humidifier
-  module Loader
+  # Pre-setting this module because AWS has a "Config" module and the below register method dynamically looks up the
+  # module to see whether or not it exists, which before ruby 2.2 would result in the warning:
+  #   `const_defined?': Use RbConfig instead of obsolete and deprecated Config.
+  module Config
+  end
 
-    class << self
-      # loop through the specs and register each class
-      def load
-        silence_warnings do
-          spec_directory = File.expand_path(File.join('..', '..', '..', 'specs', '*'), __FILE__)
-          Dir[spec_directory].each { |filepath| load_from(filepath) }
+  class Loader
+
+    # loop through the specs and register each class
+    def load
+      spec_directory = File.expand_path(File.join('..', '..', '..', 'specs', '*'), __FILE__)
+      Dir[spec_directory].each { |filepath| load_from(filepath) }
+    end
+
+    def self.load
+      new.load
+    end
+
+    private
+
+    def build_class(aws_name, spec)
+      Class.new(Resource) do
+        self.aws_name = aws_name
+        self.props = spec.each_with_object({}) do |spec_line, props|
+          prop = Props.from(spec_line)
+          props[prop.name] = prop unless prop.name.nil?
         end
       end
+    end
 
-      private
-
-      def load_from(filepath)
-        group, resource = Pathname.new(filepath).basename('.cf').to_s.split('-')
-        spec = File.readlines(filepath).select do |line|
-          # flipflop operator (http://stackoverflow.com/questions/14456634)
-          true if line.include?('Properties')...(line.strip == '}')
-        end
-        Humidifier::Resource.register(group, resource, spec[1..-2])
+    def load_from(filepath)
+      group, resource = Pathname.new(filepath).basename('.cf').to_s.split('-')
+      spec = File.readlines(filepath).select do |line|
+        # flipflop operator (http://stackoverflow.com/questions/14456634)
+        true if line.include?('Properties')...(line.strip == '}')
       end
+      register(group, resource, spec[1..-2])
+    end
 
-      # This craziness because AWS has a "Config" module and Humidifier::Resource.register dynamically looks
-      # up the module to see whether or not it exists, which before ruby 2.2 would result in the warning:
-      #   `const_defined?': Use RbConfig instead of obsolete and deprecated Config.
-      # If this is being run with RUBY_VERSION >= 2.2.0 this is effectively a noop.
-      def silence_warnings
-        old_verbose = $VERBOSE
-        begin
-          $VERBOSE = (RUBY_VERSION < '2.2.0') ? nil : old_verbose
-          yield
-        ensure
-          $VERBOSE = old_verbose
-        end
-      end
+    def register(group, resource, spec)
+      aws_name = "AWS::#{group}::#{resource}"
+      resource_class = build_class(aws_name, spec)
+
+      Humidifier.const_set(group, Module.new) unless Humidifier.const_defined?(group)
+      Humidifier.const_get(group).const_set(resource, resource_class)
+      (Resource.registry ||= {})[aws_name] = resource_class
     end
   end
 end

--- a/lib/humidifier/resource.rb
+++ b/lib/humidifier/resource.rb
@@ -72,27 +72,6 @@ module Humidifier
       def prop?(prop)
         props.key?(prop)
       end
-
-      def register(group, resource, spec)
-        aws_name = "AWS::#{group}::#{resource}"
-        resource_class = build_class(aws_name, spec)
-
-        Humidifier.const_set(group, Module.new) unless Humidifier.const_defined?(group)
-        Humidifier.const_get(group).const_set(resource, resource_class)
-        (self.registry ||= {})[aws_name] = resource_class
-      end
-
-      private
-
-      def build_class(aws_name, spec)
-        Class.new(self) do
-          self.aws_name = aws_name
-          self.props = spec.each_with_object({}) do |spec_line, props|
-            prop = Props.from(spec_line)
-            props[prop.name] = prop unless prop.name.nil?
-          end
-        end
-      end
     end
   end
 end

--- a/lib/humidifier/version.rb
+++ b/lib/humidifier/version.rb
@@ -1,3 +1,3 @@
 module Humidifier
-  VERSION = '0.0.35'.freeze
+  VERSION = '0.0.36'.freeze
 end


### PR DESCRIPTION
If you ran humidifier with ruby >= 2.0.0 and <= 2.2.0, ruby would issue a warning when you called `Object.const_defined?(:Config)`. This was previously happening because `Humidifier.const_defined?(:Config)` called up to `Object` the first time it was called because it couldn't find the module, resulting in the warning. If you short-circuit that check by defining a constant Config under the `Humidifier` module, it never gets up to Object and thereby avoids the warning entirely.

This PR also consolidates all spec loading into the `Loader` class, and thereby relieves some of the heavy-lifting from `Resource`.
