### PR TITLE
Allow users to specify the change_set_name

### DIFF
--- a/lib/humidifier/aws_adapters/sdkv2.rb
+++ b/lib/humidifier/aws_adapters/sdkv2.rb
@@ -6,7 +6,7 @@ module Humidifier
 
       # Create a change set in CFN
       def create_change_set(payload)
-        payload.merge(change_set_name: "changeset-#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}")
+        payload[:change_set_name] ||= "changeset-#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}"
         params = { stack_name: payload.identifier, template_body: payload.to_cf }.merge(payload.options)
         try_valid { client.create_change_set(params) }
       end

--- a/lib/humidifier/version.rb
+++ b/lib/humidifier/version.rb
@@ -1,4 +1,4 @@
 module Humidifier
   # Gem version
-  VERSION = '0.0.46'.freeze
+  VERSION = '0.0.47'.freeze
 end

--- a/test/aws_adapters/sdkv2_test.rb
+++ b/test/aws_adapters/sdkv2_test.rb
@@ -12,6 +12,14 @@ class SDKV2Test < Minitest::Test
     end
   end
 
+  def test_create_change_set_with_name_given
+    with_sdk_v2_loaded do |sdk|
+      SdkSupport.expect(:create_change_set, [change_set_options.merge(change_set_name: 'name')])
+      assert sdk.create_change_set(payload(identifier: 'name', to_cf: 'body', options: { change_set_name: 'name' }))
+      SdkSupport.verify
+    end
+  end
+
   def test_deploy_change_set_exists
     with_sdk_v2_loaded do |sdk|
       SdkSupport.expect(:exists?, [], true)

--- a/test/sdk_support/payload.rb
+++ b/test/sdk_support/payload.rb
@@ -1,5 +1,7 @@
 module SdkSupport
   class Payload
+    extend Forwardable
+    def_delegators :options, :[], :[]=, :merge
 
     attr_accessor :id, :identifier, :max_wait, :name, :options, :to_cf
 
@@ -9,10 +11,6 @@ module SdkSupport
       self.name       = opts[:name]
       self.options    = opts.fetch(:options, {})
       self.to_cf      = opts[:to_cf]
-    end
-
-    def merge(new_options)
-      self.options = new_options.merge(options)
     end
   end
 end


### PR DESCRIPTION
We're currently overriding the change_set_name option regardless of if the user passes it in as an option. This updates the behavior to respect what the user passed in.
