### PR TITLE
prepare for open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,10 @@ Humidifier is tested with Ruby 2.0 and higher.
 Stacks are represented with the `Humidifier::Stack` class. You can set any of the top-level JSON attributes through the initializer. Resources are represented by an exact mapping from `AWS` resource names to `Humidifier` resources names (e.g. `AWS::EC2::Instance` becomes `Humidifier::EC2::Instance`). Resources have accessors for each JSON attribute. Each attribute can also be set through the `initialize`, `update`, and `update_attribute` methods.
 
 ```ruby
-stack = Humidifier::Stack.new(
-  aws_template_format_version: '2010-09-09',
-  description: 'Example stack'
-)
+stack = Humidifier::Stack.new(name: 'Example-Stack', aws_template_format_version: '2010-09-09')
 
 load_balancer = Humidifier::ElasticLoadBalancing::LoadBalancer.new(
-  listeners: [{ 'Port' => 80, 'Protocol' => 'http', 'InstancePort' => 80, 'InstanceProtocol' => 'http' }]
+  listeners: [{ LoadBalancerPort: 80, Protocol: 'http', InstancePort: 80, InstanceProtocol: 'http' }]
 )
 load_balancer.scheme = 'internal'
 

--- a/humidifier.gemspec
+++ b/humidifier.gemspec
@@ -7,14 +7,15 @@ Gem::Specification.new do |spec|
   spec.name          = 'humidifier'
   spec.version       = Humidifier::VERSION
   spec.authors       = ['Localytics']
-  spec.email         = ['techops@localytics.com']
+  spec.email         = ['oss@localytics.com']
 
-  spec.summary       = 'Build CloudFormation templates programmatically'
+  spec.summary       = 'CloudFormation made easy'
   spec.homepage      = 'https://github.com/localytics/humidifier'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^test/}) }
+  spec.files         = Dir['LICENSE', 'README.md', 'ext/**/*', 'lib/**/*', 'specs/**/*']
   spec.require_paths = ['lib']
   spec.extensions    = ['ext/humidifier/extconf.rb']
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Update the README to have valid CFN (Port isn't good anymore, it's LoadBalancerPort). Also restrict the files in the gem (has the benefit of dropping the size of the repo from 5.9M to 768K)
